### PR TITLE
startFromEnd

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -30,15 +30,19 @@ This module is still fresh. Try it while it's hot.
 
 Where `options` defaults to:
 
-    {
-      timeout: 3000,
-      interval: 100,
-    }
+```json
+{
+    timeout: 3000,
+    interval: 100,
+    startFromEnd: false
+}
+```
 
 Time values are given in ms.
 
 * `timeout` determines after what time a file is considered to be done growing.
 * `interval` specifies the frequency at which the file is being polled for changes.
+* `startFromEnd` starts the read stream from the currently last byte.
 
 ## License
 

--- a/Readme.md
+++ b/Readme.md
@@ -16,8 +16,10 @@ This module is still fresh. Try it while it's hot.
 
 ## Usage
 
-    var file = GrowingFile.open('my-growing-file.dat');
-    file.pipe(<some writeable stream>);
+```js
+var file = GrowingFile.open('my-growing-file.dat');
+file.pipe(<some writeable stream>);
+```
 
 **Note:** The file does not have to exist yet when invoking this method. An
 `'error'` event is emitted if it is not created within the configured `timeout`.
@@ -26,7 +28,9 @@ This module is still fresh. Try it while it's hot.
 
 `GrowingFile.create` accepts an `options` array.
 
-    var file = GrowingFile.open(path, options);
+```js
+var file = GrowingFile.open(path, options);
+```
 
 Where `options` defaults to:
 

--- a/Readme.md
+++ b/Readme.md
@@ -34,7 +34,7 @@ var file = GrowingFile.open(path, options);
 
 Where `options` defaults to:
 
-```json
+```js
 {
     timeout: 3000,
     interval: 100,

--- a/lib/growing_file.js
+++ b/lib/growing_file.js
@@ -37,6 +37,11 @@ GrowingFile.open = function(path, options) {
     });
 
   file._path = path;
+  
+  // @todo Avoid sync
+  if(options.startFromEnd)
+    file._offset = fs.statSync(path).size;
+  
   file._readUntilEof();
 
   return file;

--- a/lib/growing_file.js
+++ b/lib/growing_file.js
@@ -38,11 +38,10 @@ GrowingFile.open = function(path, options) {
 
   file._path = path;
   
-  // @todo Avoid sync
   if(options.startFromEnd)
-    file._offset = fs.statSync(path).size;
-  
-  file._readUntilEof();
+    file._getFileSizeAndReadUntilEof();
+  else
+    file._readUntilEof();
 
   return file;
 };
@@ -84,6 +83,15 @@ GrowingFile.prototype._readUntilEof = function() {
   this._stream.on('data', this._handleData.bind(this));
   this._stream.on('end', this._handleEnd.bind(this));
 };
+
+GrowingFile.prototype._getFileSizeAndReadUntilEof = function(){
+    var file = this;
+    
+    fs.stat(file._path, function(error, stats){
+        file._offset = stats.size;
+        file._readUntilEof();
+    });
+}
 
 GrowingFile.prototype._retryInInterval = function() {
   setTimeout(this._readUntilEof.bind(this), this._interval);

--- a/lib/growing_file.js
+++ b/lib/growing_file.js
@@ -88,6 +88,24 @@ GrowingFile.prototype._getFileSizeAndReadUntilEof = function(){
     var file = this;
     
     fs.stat(file._path, function(error, stats){
+        if (error) {
+            file.readable = false;
+
+            if (file._timedOut()) {
+                file.emit('error', error);
+                return;
+            }
+            
+            if(error.code === GrowingFile.DOES_NOT_EXIST_ERROR) {
+                setTimeout(file._getFileSizeAndReadUntilEof.bind(file), file._interval);
+                file._idleTime += file._interval;
+                return;
+            }
+            
+            file.emit('error', error);
+            return;
+        }
+        
         file._offset = stats.size;
         file._readUntilEof();
     });

--- a/lib/growing_file.js
+++ b/lib/growing_file.js
@@ -74,9 +74,7 @@ GrowingFile.prototype._readUntilEof = function() {
   this._reading = true;
 
   this._stream = fs.createReadStream(this._path, {
-    start: this._offset,
-    // @todo: Remove if this gets merged: https://github.com/joyent/node/pull/881
-    end: Infinity
+    start: this._offset
   });
 
   this._stream.on('error', this._handleError.bind(this));


### PR DESCRIPTION
I needed to make a tiny script that reads 'growing' log files to externally monitor the output of another process whenever I wanted.

That's how I found this handy package! I needed this change in order to not load the entire log file every time.
